### PR TITLE
MySQL5.7のsql_modeのデフォルト定義が変わったのでエラーになる件を回避できるようにします。

### DIFF
--- a/includes/classes/db/mysql/query_factory.php
+++ b/includes/classes/db/mysql/query_factory.php
@@ -76,6 +76,9 @@ class queryFactory extends base {
         if (!defined('DISABLE_MYSQL_TZ_SET')) {
           mysqli_query($this->link, "SET time_zone = '" . substr_replace(date("O"),":",-2,0) . "'");
         }
+        if (defined('DB_MYSQL_MODE') && DB_MYSQL_MODE != '') {
+          mysqli_query($this->link, "SET SESSION sql_mode = '" . $this->prepare_input(DB_MYSQL_MODE) . "'");
+        }
         return true;
       } else {
         $this->set_error(mysqli_errno($this->link), mysqli_error($this->link), $dieOnErrors);


### PR DESCRIPTION
MySQL5.7ではデフォルトでsql_modeの設定が変わり、only_full_group_byがデフォルトとなりました。これによりZenCartのいくつかの画面で500エラーとなってしまうようです。

回避方法が本家の 7ffdd18 リビジョンで実装されていたので適用しました。
以降は、configure.phpで define('DB_MYSQL_MODE', '...'); を指定することでsql_modeの設定が変えられます。なお、現在のsql_modeの設定はmysqlクライアントから「```SHOW VARIABLES LIKE 'sql_mode';```」で問い合わせ可能です。

configure.phpの設定例：
```php
define('DB_MYSQL_MODE', 'NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'); 
```